### PR TITLE
Add basic Vitest setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ To get the Mi-50 game running on your local machine:
     ```
     This will create a `dist/` folder with the optimized production build.
 
+5.  **Run tests:**
+    ```bash
+    npm test
+    ```
+
 ## Project Structure
 
 -   `src/`: Contains the main application source code.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "main": "index.js",
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "test": "vitest"
   },
   "keywords": [],
   "author": "",
@@ -19,6 +20,10 @@
   "description": "",
   "devDependencies": {
     "@vitejs/plugin-react": "^4.6.0",
-    "vite": "^7.0.0"
+    "vite": "^7.0.0",
+    "vitest": "^1.0.0",
+    "jsdom": "^24.0.0",
+    "@testing-library/react": "^14.1.0",
+    "@testing-library/jest-dom": "^6.1.0"
   }
 }

--- a/src/__tests__/Mi50Game.test.tsx
+++ b/src/__tests__/Mi50Game.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Mi50Game from '../mi50_game';
+
+vi.mock('../AudioPreloader', () => ({
+  useAudioPreloader: () => ({
+    playPreloadedSound: () => {},
+    isLoading: false,
+    loadProgress: 100,
+  }),
+}));
+
+describe('Mi50Game', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<Mi50Game />);
+    expect(container).toBeTruthy();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { mergeConfig } from 'vitest/config';
+import baseConfig from './vite.config';
+
+export default mergeConfig(baseConfig, {
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest and testing library dependencies
- configure Vitest via `vitest.config.ts`
- add minimal test for `Mi50Game`
- document how to run tests in the README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68618b2f714c8325b6e3cf703b0ad934